### PR TITLE
Fix SVM and SVMGSU layers. 

### DIFF
--- a/libuacnn.py
+++ b/libuacnn.py
@@ -7,6 +7,8 @@ from collections import OrderedDict
 from theano.sandbox.rng_mrg import MRG_RandomStreams as RandomStreams
 from lasagne.random import get_rng
 
+SQRT_EPS = np.finfo(np.float32).eps
+
 
 def addUAInputLayerEst(shape=None, input_var=None, k_0=3):
     """
@@ -498,8 +500,6 @@ class SVMGSULayer(lasagne.layers.MergeLayer):
                  b=lasagne.init.Normal(0.1),
                  C=15,
                  trainable_C=True,
-                 return_cost=False,
-                 targets=None,
                  num_classes=None,
                  sample_dim=None,
                  **kwargs):
@@ -520,29 +520,28 @@ class SVMGSULayer(lasagne.layers.MergeLayer):
         self.b = self.add_param(b, (self.num_classes,), name='svm-gsu_b', regularizable=False)
         self.C = self.add_param(lasagne.init.Constant(C), (), name='svm-gsu_C', regularizable=False, trainable=trainable_C)
 
-        self.return_cost = return_cost
-
-        self.targets = targets
-
-        if (return_cost):
-            assert(self.targets is not None)
-
     def get_output_shape_for(self, input_shapes):
-        if (self.return_cost):
-            # input_shapes[0] is the minibatch size of the input
-            return (,)
-        else:
-            return (input_shapes[0][0],)
+        return (input_shapes[0][0],)
 
     def get_output_for(self, inputs, **kwargs):
-        if (self.return_cost):
-            # the inputs are means, variances
-            return self.get_cost(inputs[0], inputs[1], self.targets)
-        else:
-            return self.classify(inputs[0], inputs[1])
+        return self.classify(inputs[0], inputs[1])
 
+    def get_scores(self, input):
+        scores = T.dot(input, self.w.T) + self.b
 
-    def get_cost(self, means, variances, targets):
+        return scores
+
+    def get_class_from_scores(self, scores):
+        indices = scores.argmax(axis=1)
+
+        return self.classes[indices]
+
+    def classify(self, means, variances):
+        scores = self.get_scores(means)
+
+        return self.get_class_from_scores(scores)
+
+    def get_one_vs_all_cost_given_input_and_target(self, means, variances, targets):
         # THIS IS NOT TESTED YET!
 
         # target one hot encoded and in {-1, 1}
@@ -564,7 +563,7 @@ class SVMGSULayer(lasagne.layers.MergeLayer):
         # adding SQRT_EPS to avoid problems with the derivative of sqrt(x) when
         # x is very small. instead of sqrt(x) we use sqrt(max(x, eps))
         # dim of d_sigma is [minibatch size, self.num_classes]
-        d_sigma = T.sqrt(T.maximum(T.dot(variances, self.w.T ** 2)), SQRT_EPS)
+        d_sigma = T.sqrt(T.maximum(T.dot(variances, self.w.T ** 2), SQRT_EPS))
 
         # first part of Equation 5
         erf = 0.5 * d_mu * (T.erf((T.sqrt(2) / 2) * d_mu / d_sigma) + t)
@@ -574,7 +573,7 @@ class SVMGSULayer(lasagne.layers.MergeLayer):
         exp = (d_sigma / (T.sqrt(2 * np.pi))) * T.exp(-0.5 * (d_mu / d_sigma) ** 2)
 
         # regularization
-        num_samples = T.cast(target.shape[0], 'float32')
+        num_samples = T.cast(targets.shape[0], 'float32')
         lambda_coef = 1. / (num_samples * self.C)
 
         reg = 0.5 * lambda_coef * T.sum(self.w ** 2)
@@ -583,13 +582,6 @@ class SVMGSULayer(lasagne.layers.MergeLayer):
 
         return cost
 
-    def classify(self, means, variances):
-        # TODO
-        scores = T.dot(means, self.w.T) + self.b
-
-        indices = scores.argmax(axis=1)
-
-        return self.classes[indices]
 
 
 #
@@ -597,11 +589,11 @@ class SVMGSULayer(lasagne.layers.MergeLayer):
 # ==
 #
 
-class SVMLayer(lasagne.layers.Layer):
+class SVMLayerOLD(lasagne.layers.Layer):
     def __init__(self,
                  incoming,
-                 coef=lasagne.init.Normal(0.1),
-                 intercept=lasagne.init.Normal(0.1),
+                 w=lasagne.init.Normal(0.1),
+                 b=lasagne.init.Normal(0.1),
                  C=15,
                  trainable_C=True,
                  return_scores=False,
@@ -611,8 +603,8 @@ class SVMLayer(lasagne.layers.Layer):
 
         super(SVMLayer, self).__init__(incoming, **kwargs)
 
-        assert (coef is not None)
-        assert (intercept is not None)
+        assert (w is not None)
+        assert (b is not None)
         assert (num_classes is not None)
         assert (sample_dim is not None)
 
@@ -622,8 +614,8 @@ class SVMLayer(lasagne.layers.Layer):
         self.classes = theano.shared(np.arange(num_classes).astype('int'))
 
         # the regularization is already explicitly added later
-        self._coef = self.add_param(coef, (self.num_classes, self.sample_dim), name='svm_coef', regularizable=False)
-        self._intercept = self.add_param(intercept, (self.num_classes,), name='svm_intercept', regularizable=False)
+        self.w = self.add_param(w, (self.num_classes, self.sample_dim), name='svm_w', regularizable=False)
+        self.b = self.add_param(b, (self.num_classes,), name='svm_b', regularizable=False)
         self.C = self.add_param(lasagne.init.Constant(C), (), name='svm_C', regularizable=False, trainable=trainable_C)
 
         self.return_scores = return_scores
@@ -641,7 +633,7 @@ class SVMLayer(lasagne.layers.Layer):
             return self.classify(input)
 
     def get_scores(self, sample):
-        scores = T.dot(sample, self._coef.T) + self._intercept
+        scores = T.dot(sample, self.w.T) + self.b
 
         return scores
 
@@ -667,6 +659,82 @@ class SVMLayer(lasagne.layers.Layer):
 
         cost = T.maximum(0, 1 - y_i * scores) ** 2
         final_cost = cost.mean(axis=0).sum()
-        final_cost += 0.5 * lambda_coef * T.sum(self._coef ** 2)
+        final_cost += 0.5 * lambda_coef * T.sum(self.w ** 2)
 
         return final_cost
+
+
+
+class SVMLayer(lasagne.layers.Layer):
+    def __init__(self,
+                 incoming,
+                 w=lasagne.init.Normal(0.1),
+                 b=lasagne.init.Normal(0.1),
+                 C=15,
+                 trainable_C=True,
+                 num_classes=None,
+                 sample_dim=None,
+                 **kwargs):
+
+        super(SVMLayer, self).__init__(incoming, **kwargs)
+
+        assert (w is not None)
+        assert (b is not None)
+        assert (num_classes is not None)
+        assert (sample_dim is not None)
+
+        self.num_classes = num_classes
+        self.sample_dim = sample_dim
+
+        self.classes = theano.shared(np.arange(num_classes).astype('int'))
+
+        # the regularization is already explicitly added later
+        self.w = self.add_param(w, (self.num_classes, self.sample_dim), name='svm_w', regularizable=False)
+        self.b = self.add_param(b, (self.num_classes,), name='svm_b', regularizable=False)
+        self.C = self.add_param(lasagne.init.Constant(C), (), name='svm_C', regularizable=False, trainable=trainable_C)
+
+    def get_output_shape_for(self, input_shape):
+        return (input_shape[0],)
+
+    def get_output_for(self, input, **kwargs):
+        return self.classify(input)
+
+    def get_scores(self, sample):
+        scores = T.dot(sample, self.w.T) + self.b
+
+        return scores
+
+    def get_class_from_scores(self, scores):
+        indices = scores.argmax(axis=1)
+
+        return self.classes[indices]
+
+    def classify(self, sample):
+        scores = self.get_scores(sample)
+
+        return self.get_class_from_scores(scores)
+
+    def get_one_vs_all_cost_from_scores(self, scores, target):
+        # this is squared hinge loss!
+
+        # target one hot encoded and in {-1, 1}
+        t = T.extra_ops.to_one_hot(target, self.num_classes) * 2
+        t -= 1
+
+        num_samples = T.cast(target.shape[0], 'float32')
+        lambda_coef = 1. / (num_samples * self.C)
+
+        reg = 0.5 * lambda_coef * T.sum(self.w ** 2)
+
+        cost = T.maximum(0, 1 - t * scores) ** 2
+        final_cost = reg + cost.mean(axis=0).sum()
+
+        return final_cost
+
+    def get_one_vs_all_cost_given_input_and_target(self, input, target):
+        # this is squared hinge loss!
+
+        scores = self.get_scores(input)
+        cost = self.get_one_vs_all_cost_from_scores(scores, target)
+
+        return cost


### PR DESCRIPTION
Add ccffsvm-ua-test architecture that uses small constant sigmas. Change how cost of SVM layers is calculated.

Two running examples:

pp305@charybdis:~/christos/cnn-playground$ python runCNN.py -a ccffsvm-ua-test
Using gpu device 0: GeForce GTX TITAN X (CNMeM is enabled with initial size: 20.0% of memory, cuDNN 5103)
 # Training a CNN on cifar10 with: 
    -- Architecture     : ccffsvm-ua-test
    -- Number of epochs : 100
    -- Batch size       : 256
    -- Iteration        : 1
 # Loading data...Done!
 # Building network model and compiling functions...Done!
 # Number of parameters in model: 1323915
 # Starting training...
 # Final results:
   test loss:			1.423942
   test accuracy:		74.83 %


pp305@charybdis:~/christos/cnn-playground$ python runCNN.py -a ccffsvm-ap
Using gpu device 0: GeForce GTX TITAN X (CNMeM is enabled with initial size: 20.0% of memory, cuDNN 5103)
 # Training a CNN on cifar10 with: 
    -- Architecture     : ccffsvm-ap
    -- Number of epochs : 100
    -- Batch size       : 256
    -- Iteration        : 1
 # Loading data...Done!
 # Building network model and compiling functions...Done!
 # Number of parameters in model: 1323915
 # Starting training...
 # Final results:
   test loss:			2.638446
   test accuracy:		74.18 %

